### PR TITLE
Fix error on macOS Notion 2.0.24

### DIFF
--- a/insert/electronApi.cjs
+++ b/insert/electronApi.cjs
@@ -134,7 +134,7 @@ globalThis.__enhancerElectronApi = {
   version: require('notion-enhancer/package.json').version,
   db,
 
-  browser: isRenderer ? require('electron').remote.getCurrentWindow() : {},
+  browser: isRenderer ? require('electron').remote?.getCurrentWindow() : {},
   webFrame: isRenderer ? require('electron').webFrame : {},
   notionRequire: (path) => require(`../../${path}`),
   notionPath: (path) => require('path').resolve(`${__dirname}/../../${path}`),


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**

notion-enhancer fails to load on Notion 2.0.24, with the following error:

```
Uncaught (in promise) TypeError: Cannot read property 'getCurrentWindow' of undefined
    at Object.<anonymous> (notion://www.notion.so/Applications/Notion.app/Contents/Resources/app/node_modules/notion-enhancer/electronApi.cjs:137)
    at Object.<anonymous> (notion://www.notion.so/Applications/Notion.app/Contents/Resources/app/node_modules/notion-enhancer/electronApi.cjs:171)
    at Module._compile (internal/modules/cjs/loader.js:1152)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1173)
    at Module.load (internal/modules/cjs/loader.js:992)
    at Module._load (internal/modules/cjs/loader.js:885)
    at Function.f._load (electron/js2c/asar_bundle.js:5)
    at Module.require (internal/modules/cjs/loader.js:1032)
    at require (internal/modules/cjs/helpers.js:72)
    at module.exports (notion://www.notion.so/Applications/Notion.app/Contents/Resources/app/node_modules/notion-enhancer/init.cjs:10)
```

**What does your code do and why?**

It appears the app initialize some stuff later than it used to, hence the non-existent `require('electron').remote`.

Allowing it defaults to empty seems to make notion-enhancer work again, at least for basic functionality.