### PR TITLE
Add trailing semicolon when appending to preload script

### DIFF
--- a/pkg/apply.mjs
+++ b/pkg/apply.mjs
@@ -75,7 +75,7 @@ export default async function (
       }
       await fsp.appendFile(
         file,
-        `\n\n//notion-enhancer\nrequire('notion-enhancer')('${target}', exports, (js) => eval(js))`
+        `\n\n//notion-enhancer\nrequire('notion-enhancer')('${target}', exports, (js) => eval(js));`
       );
     }
   }


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**

This may seem a little nitpicking so let me explain the motivation.

I also made some [customization](https://github.com/kidonng/cherry/tree/master/scripts#block-notion-analytics) [scripts](https://github.com/kidonng/cherry/tree/master/scripts#notion-localization) for Notion, but they are nothing big like notion-enhancer so I just recommend installing via `curl script >> preload.js`. The problem is the script is bundled in to IIFEs `(() => {})()` without [a leading semicolon](https://stackoverflow.com/questions/1873983/what-does-the-leading-semicolon-in-javascript-libraries-do), so they won't work if appended directly after notion-enhacer.

To be honest this is more of an issue of myself rather than notion-enhancer, I can just adjust the bundler or prepending a semicolon beforehand, but this trivial change could also benefit other people/mods out there.

**What does your code do and why?**

Adding a harmless semicolon when notion-enhancer patching Notion app's preload script, to make life easier for people who want to do other customization.