### PR TITLE
Fix a bug in the Ouliner extension

### DIFF
--- a/src/extensions/outliner/client.mjs
+++ b/src/extensions/outliner/client.mjs
@@ -43,14 +43,12 @@ export default async function ({ web, components }, db) {
     $headingList.style.display = '';
     const $headerBlocks = $page.querySelectorAll('[class^="notion-"][class*="header-block"]'),
       $fragment = web.html`<div></div>`;
-    let depth = 0,
-      indent = 0;
+    let indent = 0;
     for (const $header of $headerBlocks) {
       const id = $header.dataset.blockId.replace(/-/g, ''),
         placeholder = $header.querySelector('[placeholder]').getAttribute('placeholder'),
         headerDepth = +[...placeholder].reverse()[0];
       indent = (headerDepth-1) * 18;
-      depth = headerDepth;
       const $outlineHeader = web.render(
         web.html`<a href="#${id}" class="outliner--header"
               placeholder="${web.escape(placeholder)}"

--- a/src/extensions/outliner/client.mjs
+++ b/src/extensions/outliner/client.mjs
@@ -49,11 +49,7 @@ export default async function ({ web, components }, db) {
       const id = $header.dataset.blockId.replace(/-/g, ''),
         placeholder = $header.querySelector('[placeholder]').getAttribute('placeholder'),
         headerDepth = +[...placeholder].reverse()[0];
-      if (depth && depth < headerDepth) {
-        indent += 18;
-      } else if (depth > headerDepth) {
-        indent = Math.max(indent - 18, 0);
-      }
+      indent = (headerDepth-1) * 18;
       depth = headerDepth;
       const $outlineHeader = web.render(
         web.html`<a href="#${id}" class="outliner--header"


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**
Issue #813

**What does your code do and why?**
This code fixes an indentation bug in the Outliner extension (@runargs ).

Originally, the indentation level was incremented /decremented by 18 at each iteration.
This caused a bug, e.g., when jumping from level 3 to level 1. See #813 for further details.

The fix multiplies the header level minus 1 by 18. This way, jumping from level 3 to level 1 results in the correct indentation.