### PR TITLE
Enable Scrolling for Outliner, Previously in Overflow State

### DIFF
--- a/src/extensions/outliner/client.css
+++ b/src/extensions/outliner/client.css
@@ -5,6 +5,10 @@
  * (https://notion-enhancer.github.io/) under the MIT license
  */
 
+#enhancer--panel {
+  overflow: auto;
+}
+
 #outliner--notice {
   color: var(--theme--text_secondary);
   font-size: 14px;
@@ -39,8 +43,8 @@
 }
 
 /* indentation lines */
-.outliner--header:not([style='--outliner--indent:0px;'])::before {
-  content: '';
+.outliner--header:not([style="--outliner--indent:0px;"])::before {
+  content: "";
   height: 100%;
   position: absolute;
   left: calc((1rem + var(--outliner--indent)) - 11px);


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**

My Personal Experience

**What does your code do and why?**

Enable Scrolling for Outliner, Previously in Overflow State

<img width="339" alt="image" src="https://github.com/notion-enhancer/notion-enhancer/assets/33340988/bc84b9d9-a813-4c66-9155-099c4c0c9a01">
