### PR TITLE
fix: load extension in Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "bin": "bin.mjs",
   "type": "module",
   "scripts": {
-    "build": "./scripts/build-browser-extension.sh",
+    "build": "./scripts/build-browser-extension.sh chrome",
+    "build:firefox": "./scripts/build-browser-extension.sh firefox",
     "vendor": "node ./scripts/vendor-dependencies.mjs"
   },
   "engines": {

--- a/scripts/build-browser-extension.sh
+++ b/scripts/build-browser-extension.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
+set -e
 
+BROWSER=${1:-chrome}
 version=$(node -p "require('./package.json').version")
+builddir="dist/build/$BROWSER"
 
-cd src
-mkdir -p ../dist
-rm -f "../dist/notion-enhancer-$version.zip"
-zip -r9 "../dist/notion-enhancer-$version.zip" .
+rm -rf "$builddir"
+mkdir -p "$builddir"
+cp -r src/. "$builddir/"
+
+if [ "$BROWSER" = "firefox" ]; then
+  # Switch `service_worker: "x.js"`` to `scripts: ["x.js"]` for Firefox,
+  sed -i 's/"service_worker": "\/worker.js"/"scripts": ["\/worker.js"]/' "$builddir/manifest.json"
+fi
+
+outfile="dist/notion-enhancer-$version-$BROWSER.zip"
+rm -f "$outfile"
+(cd "$builddir" && zip -r9 - .) > "$outfile"
+
+echo "Built $outfile"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,11 @@
 {
   "manifest_version": 3,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "notion-enhancer@notion-enhancer.github.io",
+      "strict_min_version": "138.0"
+    }
+  },
   "name": "notion-enhancer",
   "version": "0.11.1",
   "author": "dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)",


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**

https://github.com/notion-enhancer/notion-enhancer/issues/951

**What does your code do and why?**

It enables the newest version of the extension to build for Firefox, with `npm run build:firefox`. The only necessary changes were:

* Setting `browser_specific_settings.gecko.id` in the manifest
* Changing `background.service_worker` to `background.scripts`
* Making a change in the manifest file requires doing some munging on the Firefox build, but it's not too crazy

There's a [bunch of warnings](https://gist.githubusercontent.com/vasi/1308a89abd9c46f273723ad222fbd3b8/raw/b03e40923f2db162bfec637abec12ecca7951574/gistfile1.txt) in about:debugging when loading the extension into Firefox, but no errors, and I don't think any of these are important. It's just the validator being a bit pedantic. All the features I've tried have worked.